### PR TITLE
quotes form submission to prevent clipping at first space

### DIFF
--- a/templates/national_view.html
+++ b/templates/national_view.html
@@ -139,7 +139,7 @@
               <option value="{{ area }}">{{ area }}</option>
             {% endfor %} 
           </select> 
-          <button class="btn btn-dark" id="exploreBtn" type="submit">Explore ></button> 
+          <button class="btn btn-dark" id="exploreBtn" type="submit">Explore &gt;</button> 
         </form>
 
       </div>

--- a/templates/national_view.html
+++ b/templates/national_view.html
@@ -101,7 +101,7 @@
                 <h6>Month</h6>
                 <select id= "month-select" name="month" class="selectpicker">
                   {% for month in month_list %} 
-                    <option value= {{ month }}>{{ month }}</option>
+                    <option value="{{ month }}">{{ month }}</option>
                   {% endfor %} 
                 </select>              
               </li>
@@ -136,7 +136,7 @@
         <form action="{{ url_for('metro') }}" method="GET">
           <select class="selectpicker" id= "area-select" name="metroArea" data-live-search="true" data-width="500px">
             {% for area in area_list %} 
-              <option value= {{ area }}>{{ area }}</option>
+              <option value="{{ area }}">{{ area }}</option>
             {% endfor %} 
           </select> 
           <button class="btn btn-dark" id="exploreBtn" type="submit">Explore ></button> 


### PR DESCRIPTION
The value is not quoted in these HTML forms so only text up to the first space is submitted, the rest is assumed to be part of the tag attributes. This causes an issue for areas with a space in their names.

cc @bndodson @JingzongWang 